### PR TITLE
update instructions for Tails 1.4

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -45,7 +45,9 @@ $GOPATH/bin/client</pre>
 
 <p>Same as Ubuntu, above, but 1) on the <tt>go get</tt> command line add <tt>-tags ubuntu</tt> before the URL and 2) the gtkspell package is called <tt>libgtkspell-3-dev</tt>. On more recent versions of Debian, the instructions should be exactly the same as Ubuntu.</p>
 
-<h5>Tails (Version 1.1.1)</h5>
+<h5>Tails (Version 1.4)</h5>
+
+<p>Please check back for future versions of Tails as these instructions will likely change.
 
 <p>First, if you have not done so already, configure Tails persistence (<em>Applications</em> &rarr; <em>Tails</em> &rarr; <em>Configure persistent volume</em>) to persist "Personal Data", "APT Packages", "APT Lists", and "Dotfiles". A reboot is required after these settings are changed.</p>
 
@@ -55,26 +57,43 @@ $GOPATH/bin/client</pre>
 
 <pre>echo 'export GOPATH=$HOME/Persistent/go/' &gt;&gt; ~/.bashrc
 . ~/.bashrc
-mkdir $GOPATH
-alias pond-build='sudo bash -c "sudo apt-get update &amp;&amp; \
-apt-get install -y -t testing golang &amp;&amp; \
-apt-get install -y gcc git mercurial libgtk-3-dev libgtkspell-3-dev libtspi-dev trousers" &amp;&amp; \
-go get -u -tags ubuntu github.com/agl/pond/client &amp;&amp; \
-echo "Success." || echo "Sorry, something went wrong."'
-alias pond-install-deps='sudo apt-get install libtspi1 libgtkspell-3-0'
+mkdir -p $GOPATH/src/github.com/agl
+mkdir -p $GOPATH/src/github.com/golang
+mkdir -p $GOPATH/src/golang.org/x
+
+cd $GOPATH/src/golang.org/x
+git clone https://github.com/golang/crypto
+git clone https://github.com/golang/net
+
+cd $GOPATH/src/github.com/agl
+git clone https://github.com/agl/pond
+git clone https://github.com/agl/ed25519
+git clone https://github.com/agl/go-gtk
+
+cd $GOPATH/src/github.com/golang
+git clone https://github.com/golang/protobuf
+
+cd $GOPATH/src/github.com/agl/pond/client
+go install -tags ubuntu
+
 alias pond='$GOPATH/bin/client'
 alias pond-cli='$GOPATH/bin/client --cli'
 alias|grep pond &gt;&gt; ~/.bashrc
-pond-build</pre>
+</pre>
+Now configure persistent storage to automatically reinstall dependencies using the Additional Software feature.
+The Additional Software feature will check for updated versions of the packages below on each boot and install them.
+<pre>
+sudo bash -c 'echo "libtspi1" &gt;&gt; /live/persistence/TailsData_unlocked/live-additional-software.conf'
+sudo bash -c 'echo "libgtkspell-3-0" &gt;&gt; /live/persistence/TailsData_unlocked/live-additional-software.conf'
+</pre>
 
 <p>Finally, run the following command (if you have not previously done so) to add your <tt>~/.bashrc</tt> to the persistent storage:</p>
 <pre>cp ~/.bashrc /live/persistence/TailsData_unlocked/dotfiles/.bashrc</pre>
 
-<p>Each time you start Tails in the future, before you can run Pond, you'll just need to reinstall its runtime dependencies using the <tt>pond-install-deps</tt> command.</p>
-
 <p>At this point, you should be able to run Pond's graphical interface with the <tt>pond</tt> command, or run its command-line interface with the <tt>pond-cli</tt> command.</p>
+<p>You will need to have an administrator password enabled on booting Tails for the Additional Software feature.
 
-<p>From time to time you can re-run the <tt>pond-build</tt> command to update to the latest version.</p>
+<p>From time to time you may want to re-download and build Pond to update to the latest version.</p>
 
 <h5>Fedora 19</h5>
 


### PR DESCRIPTION
Update Pond build instructions for Tails 1.4 to manually download source code over https until Tails includes a version of go that does not download code over http, use the Additional Software feature instead of aliases to manage dependencies, and updates notes accordingly.
